### PR TITLE
Clean up: move the installation assets to $install_dir

### DIFF
--- a/conf/env
+++ b/conf/env
@@ -1,1 +1,1 @@
-UMAP_SETTINGS=__DATA_DIR__/settings.py
+UMAP_SETTINGS=__INSTALL_DIR__/settings.py

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,8 +10,8 @@ location __PATH__/static/ {
 }
 
 # Geojson files
-location __PATH__/uploads/ {
-    alias __INSTALL_DIR__/data/;
+location __PATH__/media/ {
+    alias __DATA_DIR__/data/;
     expires 30d;
 }
 
@@ -25,7 +25,7 @@ location __PATH__/internal/ {
     gzip_vary on;
     gzip_static on;
     more_set_headers "X-DataLayer-Version: $upstream_http_x_datalayer_version";
-    alias __INSTALL_DIR__/data/;
+    alias __DATA_DIR__/data/;
 }
 
 # Ajax proxy

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -4,7 +4,7 @@
 ################################################################################
 
 # Please do not modify this file, it will be reset at the next update.
-# You can edit the file __DATA_DIR__/local_settings.py and add/modify the settings you need.
+# You can edit the file __INSTALL_DIR__/local_settings.py and add/modify the settings you need.
 # The parameters you add in local_settings.py will overwrite these,
 # but you can use the options and documentation in this file to find out what can be done.
 
@@ -145,9 +145,9 @@ else:
     MEDIA_URL = "/media/"
 
 STATIC_ROOT = str(INSTALL_DIR_PATH / "static")
-MEDIA_ROOT = str(INSTALL_DIR_PATH / "media")
+MEDIA_ROOT = str(DATA_DIR_PATH / "data")
 UMAP_PICTOGRAMS_COLLECTIONS = {
-    "OSMIC": {"path": DATA_DIR_PATH / "icons", "attribution": "Osmic"},
+    "OSMIC": {"path": INSTALL_DIR_PATH / "icons", "attribution": "Osmic"},
 }
 
 # Do not allow to edit username, as it's managed by the Yunohost SSO

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -4,9 +4,9 @@ After=network.target redis.service postgresql.service
 
 [Service]
 User=__APP__
-WorkingDirectory=__DATA_DIR__/
-EnvironmentFile=__DATA_DIR__/.env
-ExecStart=__DATA_DIR__/.venv/bin/uvicorn --proxy-headers --no-access-log --port __PORT__ umap.asgi:application
+WorkingDirectory=__INSTALL_DIR__/
+EnvironmentFile=__INSTALL_DIR__/.env
+ExecStart=__INSTALL_DIR__/.venv/bin/uvicorn --proxy-headers --no-access-log --port __PORT__ umap.asgi:application
 
 
 #____________________________________________________________________________________

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -15,16 +15,13 @@ services = ["__APP__"]
         ask = "from email"
         type = "email"
         help = "Default email address to use for various automated emails."
-        #
-        # We can't use "__DATA_DIR__" in bind value, because of this bug:
-        # https://github.com/YunoHost/issues/issues/2283
-        bind = "default_from_email:/home/yunohost.app/__APP__/settings.py"
+        bind = "default_from_email:__INSTALL_DIR__/settings.py"
 
         [main.config.admin_email]
         ask = "ADMIN email"
         type = "email"
         help = "Email address for error emails."
-        bind = "admin_email:/home/yunohost.app/__APP__/settings.py"
+        bind = "admin_email:__INSTALL_DIR__/settings.py"
 
         [main.config.realtime]
         ask = "Realtime"
@@ -32,7 +29,7 @@ services = ["__APP__"]
         yes = "1"
         no = "0"
         help = "Allow for realtime collaboration"
-        bind = "realtime:/home/yunohost.app/__APP__/settings.py"
+        bind = "realtime:__INSTALL_DIR__/settings.py"
 
         [main.config.allow_anonymous]
         ask = "Anonymous edition"
@@ -40,28 +37,28 @@ services = ["__APP__"]
         yes = "1"
         no = "0"
         help = "Allow for non logged in users to create and edit maps"
-        bind = "allow_anonymous:/home/yunohost.app/__APP__/settings.py"
+        bind = "allow_anonymous:__INSTALL_DIR__/settings.py"
 
         [main.config.default_longitude]
         ask = "Default longitude"
         type = "string"
         default = "2.0"
         help = "Default longitude for new maps"
-        bind = "default_longitude:/home/yunohost.app/__APP__/settings.py"
+        bind = "default_longitude:__INSTALL_DIR__/settings.py"
 
         [main.config.default_latitude]
         ask = "Default latitude"
         type = "string"
         default = "51.0"
         help = "Default latitude for new maps"
-        bind = "default_latitude:/home/yunohost.app/__APP__/settings.py"
+        bind = "default_latitude:__INSTALL_DIR__/settings.py"
 
         [main.config.default_zoom]
         ask = "Default zoom"
         type = "number"
         default = 6
         help = "Default zoom for new maps"
-        bind = "default_zoom:/home/yunohost.app/__APP__/settings.py"
+        bind = "default_zoom:__INSTALL_DIR__/settings.py"
 
         [main.config.openrouteservice]
         ask = "OpenRouteService"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -42,7 +42,10 @@ myynh_fix_file_permissions() {
     # /var/www/$app/
     # static files served by nginx, so use www-data group:
     chown -c -R "$app:www-data" "$install_dir"
+    # TODO: forbid write access to $app for the install_dir
     chmod -c u+rwx,g+rx,o-rwx "$install_dir"
+    # TODO: give read/write access to local_settings.py only to root
+    # and give read-only access to $app (or www-data?) so they can read it.
 
     # /home/yunohost.app/$app/
     chown -c -R "$app:$app" "$data_dir"

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -24,7 +24,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Update $app settings file..."
 
-ynh_config_add --template="settings.py" --destination="$data_dir/settings.py"
+ynh_config_add --template="settings.py" --destination="$install_dir/settings.py"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -20,6 +20,9 @@ ynh_app_setting_set --key=log_file --value="$log_file"
 redis_db=$(ynh_redis_get_free_db)
 ynh_app_setting_set --key=redis_db --value="$redis_db"
 
+# TODO: this email should rather be set in 2 distinct variables
+# and then stored in yunohost settings, so the user can customize their
+# values through the config panel
 email=$(ynh_user_get_info --username=$admin --key=mail)
 
 #=================================================
@@ -27,7 +30,7 @@ email=$(ynh_user_get_info --username=$admin --key=mail)
 #=================================================
 ynh_script_progression "Validating installation parameters..."
 
-mkdir -p "$install_dir/data" "$install_dir/static"
+mkdir -p "$data_dir/data" "$install_dir/static"
 
 #=================================================
 # SETUP LOG FILE
@@ -43,8 +46,8 @@ ynh_config_add_logrotate "$log_file"
 # PYTHON VIRTUALENV
 #=================================================
 ynh_script_progression "Setup Python virtualenv for $app ..."
-ynh_exec_as_app python3 -m venv $data_dir/.venv
-ynh_exec_as_app $data_dir/.venv/bin/pip install -r "../conf/requirements.txt"
+ynh_exec_as_app python3 -m venv $install_dir/.venv
+ynh_exec_as_app $install_dir/.venv/bin/pip install -r "../conf/requirements.txt"
 
 #=================================================
 # copy config files
@@ -58,45 +61,45 @@ ynh_app_setting_set_default --key=openrouteservice --value=""
 ynh_app_setting_set_default --key=allow_anonymous --value=0
 ynh_app_setting_set_default --key=realtime --value=1
 
-ynh_config_add --template="settings.py" --destination="$data_dir/settings.py"
-ynh_config_add --template="setup_user.py" --destination="$data_dir/setup_user.py"
-ynh_config_add --template="env" --destination="$data_dir/.env"
+ynh_config_add --template="settings.py" --destination="$install_dir/settings.py"
+ynh_config_add --template="setup_user.py" --destination="$install_dir/setup_user.py"
+ynh_config_add --template="env" --destination="$install_dir/.env"
 
-touch "$data_dir/local_settings.py"
+touch "$install_dir/local_settings.py"
 
 #=================================================
 # copy icon files
 # ================================================
 ynh_script_progression "copy icons..."
 
-cp -r ../conf/icons "$data_dir/icons"
+cp -r ../conf/icons "$install_dir/icons"
 
 #=================================================
 # MIGRATE / COLLECTSTATIC / CREATEADMIN
 #=================================================
 ynh_script_progression "migrate/collectstatic/createadmin..."
 
-pushd "$data_dir"
+pushd "$install_dir"
     set -a
-    . $data_dir/.env
+    . $install_dir/.env
     set +a
 
     # Just for debugging:
-    $data_dir/.venv/bin/umap diffsettings
+    $install_dir/.venv/bin/umap diffsettings
 
-    $data_dir/.venv/bin/umap collectstatic --no-input
+    $install_dir/.venv/bin/umap collectstatic --no-input
     ynh_psql_db_shell $db_name <<< "CREATE EXTENSION IF NOT EXISTS postgis;"
     ynh_psql_db_shell $db_name <<< "CREATE EXTENSION IF NOT EXISTS unaccent;"
-    $data_dir/.venv/bin/umap migrate --no-input
+    $install_dir/.venv/bin/umap migrate --no-input
 
     # Create/update Django superuser (set unusable password, because auth done via SSOwat):
     # Call create_superuser from django_yunohost_integration instead of Django builtin.
-    $data_dir/.venv/bin/umap create_superuser --username="$admin" --email="$(ynh_user_get_info --username="$admin" --key=mail)"
+    $install_dir/.venv/bin/umap create_superuser --username="$admin" --email="$(ynh_user_get_info --username="$admin" --key=mail)"
 popd
 
 # Check the configuration
 # This may fail in some cases with errors, etc., but the app works and the user can fix issues later.
-$data_dir/.venv/bin/umap check --deploy || true
+$install_dir/.venv/bin/umap check --deploy || true
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -8,8 +8,6 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Removing system configurations related to $app..."
 
-ynh_safe_rm "$data_dir" # See https://github.com/YunoHost-Apps/umap_ynh/issues/11
-
 # Remove the app-specific logrotate config
 ynh_config_remove_logrotate
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,6 +7,9 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
+# TODO: remove it when we store the admin email and the default email in the settings
+# so we don't overwrite their values accross upgrades and respect user's choice if
+# they customized it through the config panel.
 email=$(ynh_user_get_info --username=$admin --key=mail)
 
 #=================================================
@@ -20,10 +23,9 @@ ynh_systemctl --service=$app --action="stop" --log_path="$log_file"
 # PYTHON VIRTUALENV
 #=================================================
 ynh_script_progression "Setup Python virtualenv for $app ..."
-ynh_safe_rm "$data_dir/.venv" # FIXME: We should probably not install anything in $data_dir
-                              # $install_dir is meant for that
-ynh_exec_as_app python3 -m venv $data_dir/.venv
-ynh_exec_as_app $data_dir/.venv/bin/pip install -r "../conf/requirements.txt"
+ynh_safe_rm "$install_dir/.venv" # Remove all and recreate the virtualenv.
+ynh_exec_as_app python3 -m venv $install_dir/.venv
+ynh_exec_as_app $install_dir/.venv/bin/pip install -r "../conf/requirements.txt"
 
 #=================================================
 # copy config files
@@ -36,31 +38,40 @@ ynh_app_setting_set_default --key=default_zoom --value=6
 ynh_app_setting_set_default --key=openrouteservice --value=""
 ynh_app_setting_set_default --key=allow_anonymous --value=0
 ynh_app_setting_set_default --key=realtime --value=1
-ynh_config_add --template="settings.py" --destination="$data_dir/settings.py"
-ynh_config_add --template="setup_user.py" --destination="$data_dir/setup_user.py"
-ynh_config_add --template="env" --destination="$data_dir/env"
+ynh_config_add --template="settings.py" --destination="$install_dir/settings.py"
+ynh_config_add --template="setup_user.py" --destination="$install_dir/setup_user.py"
+ynh_config_add --template="env" --destination="$install_dir/.env"
+mkdir -p "$data_dir/data" "$install_dir/static"
+
+#=================================================
+# copy icon files
+# ================================================
+ynh_script_progression "copy icons..."
+
+cp -rT ../conf/icons/ "$install_dir/icons"
+
 
 #=================================================
 # MIGRATE APP
 #=================================================
 ynh_script_progression "migrate/collectstatic/createadmin..."
 
-pushd "$data_dir"
+pushd "$install_dir"
     set -a
-    . $data_dir/.env
+    . $install_dir/.env
     set +a
 
     # Just for debugging:
-    $data_dir/.venv/bin/umap diffsettings
+    $install_dir/.venv/bin/umap diffsettings
 
-    $data_dir/.venv/bin/umap collectstatic --no-input
+    $install_dir/.venv/bin/umap collectstatic --no-input
     ynh_psql_db_shell $db_name <<< "CREATE EXTENSION IF NOT EXISTS postgis;"
     ynh_psql_db_shell $db_name <<< "CREATE EXTENSION IF NOT EXISTS unaccent;"
-    $data_dir/.venv/bin/umap migrate --no-input
+    $install_dir/.venv/bin/umap migrate --no-input
 
     # Check the configuration
     # This may fail in some cases with errors, etc., but the app works and the user can fix issues later.
-    $data_dir/.venv/bin/umap check --deploy || true
+    $install_dir/.venv/bin/umap check --deploy || true
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- The app was installed in the data dir, which was not consistent and produced an error when restoring the app after an upgrade failure

## Solution

- Install the app in the install dir