### PR TITLE
Allow the yunohost autoupdate to run

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,1 +1,0 @@
-umap-project[yunohost,sync]==3.5.0

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,6 +66,16 @@ ram.runtime = "150M" # **estimate** minimum ram requirement. e.g. 50M, 400M, 1G,
 
 
 [resources]
+
+    [resources.sources.main]
+    url = "https://github.com/umap-project/umap/archive/refs/tags/3.5.0.tar.gz"
+    sha256 = "26183d0f35ae2fafaaac35e9b52010554bf5516ea98bd4c0dd0c4fe77fc53c02"
+
+    # Only here to bump the package version
+    prefetch = false
+
+    autoupdate.strategy = "latest_github_release"
+
     [resources.system_user]
     # This will provision/deprovision a unix system user
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,9 @@
 
 # Transfer the main SSO domain to the App:
 ynh_current_host=$(cat /etc/yunohost/current_host)
-__YNH_CURRENT_HOST__=${ynh_current_host} # Useful? Sounds like not, and there is a confusion.
+__YNH_CURRENT_HOST__=${ynh_current_host} # FIXME: Useful? Sounds like not, and there is a confusion.
+
+umap_with_extra_deps="umap-project[yunohost,sync]"
 
 #=================================================
 # SET CONSTANTS

--- a/scripts/install
+++ b/scripts/install
@@ -46,8 +46,8 @@ ynh_config_add_logrotate "$log_file"
 # PYTHON VIRTUALENV
 #=================================================
 ynh_script_progression "Setup Python virtualenv for $app ..."
-ynh_exec_as_app python3 -m venv $install_dir/.venv
-ynh_exec_as_app $install_dir/.venv/bin/pip install -r "../conf/requirements.txt"
+ynh_exec_as_app python3 -m venv "$install_dir/.venv"
+ynh_exec_as_app "$install_dir/.venv/bin/pip" install "${umap_with_extra_deps}==$(ynh_app_upstream_version)"
 
 #=================================================
 # copy config files

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,9 +23,8 @@ ynh_systemctl --service=$app --action="stop" --log_path="$log_file"
 # PYTHON VIRTUALENV
 #=================================================
 ynh_script_progression "Setup Python virtualenv for $app ..."
-ynh_safe_rm "$install_dir/.venv" # Remove all and recreate the virtualenv.
-ynh_exec_as_app python3 -m venv $install_dir/.venv
-ynh_exec_as_app $install_dir/.venv/bin/pip install -r "../conf/requirements.txt"
+ynh_exec_as_app python3 -m venv "$install_dir/.venv"
+ynh_exec_as_app "$install_dir/.venv/bin/pip" install "${umap_with_extra_deps}==$(ynh_app_upstream_version)" --upgrade
 
 #=================================================
 # copy config files


### PR DESCRIPTION
## The benefits

This autoupdate runner will run around every day to check whether there exist a new version of umap. When it does, it will automatically open a PR in Github to bump the version for you and run the CI (that runs the night, so you directly see the result in the morning).

Also it enforces a consistency between the package app version and the effectively installed app version (problem we've got once before [this PR](https://github.com/YunoHost-Apps/umap_ynh/pull/18) has been merged).

An example of such PR: https://github.com/YunoHost-Apps/borg_ynh/pull/246

## Proposed technical solution

I propose to specify the source assets. This is only meant for the autoupdater to run, it has no effect on the Yunohost admin side (thanks to the `prefetch = false` attribute in the manifest).

The `requirements.txt` file is removed, we specify the package and its extra dependency as a variable in the `_common.sh` file. The upstream version is then got from the [ynh_app_upstream_version helper function](https://github.com/YunoHost/yunohost/blob/9161d8efe60b48c113cad24744887e1ec4126ae6/helpers/helpers.v2.1.d/0-utils#L207-L215) (also [documented here](https://doc.yunohost.org/fr/dev/packaging/scripts/helpers_v2.1/)).