### PR TITLE
Admin doc improvements

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,15 +1,18 @@
-## Settings and upgrades
+# Settings
 
-Almost everything related to Django Example's configuration is handled in a `"../conf/settings.py"` file.
-You can edit the file `/home/yunohost.app/umap/local_settings.py` to enable or disable features.
+Almost everything related to Umap's configuration is handled in a `"__INSTALL_DIR__/conf/settings.py"` file. You should not edit this file manually, otherwise your changes will be overwritten.
+You can instead edit the file `__INSTALL_DIR__/local_settings.py` to enable or disable features.
 
-Test sending emails, e.g.:
+## Testing the emails are sent
+
+You may log in to Yunohost using ssh and run the following command:
 
 ```bash
-ssh admin@yourdomain.tld
 root@yunohost:~# /home/yunohost.app/umap/manage.py sendtestemail --admins
 ```
 
-How to debug a django YunoHost app, take a look into:
+## Debugging Umap
+
+Take a look at:
 
 * https://github.com/YunoHost-Apps/umap_ynh#developer-info


### PR DESCRIPTION
~~(In draft, I notice an issue with the admin panel)~~

I assume in this PR that this file will be read mostly in the web administration panel (this is arguable):

<img width="934" height="423" alt="Admin doc as rendered below the config panel" src="https://github.com/user-attachments/assets/5fe034df-1cb3-46b1-aa36-de27eea8a759" />

Few changes to the admin documentation:
1. Don't assume the location of the settings. Umap can be installed several times. Hence the use of `__INSTALL_DIR__`
2. Explain a bit more the role of the settings.py file
3. the `ssh admin@yourdomain.tld` is not suitable to the latest version of Yunohost as the `admin` user is deprecated and removed in the latest version of Yunohost. I suggest to assume the user knows how to use ssh.
4. Add sections to the admin doc for more clarity