### PR TITLE
Various cleanups

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -28,8 +28,7 @@ assert DATA_DIR_PATH.is_dir(), f"Directory not exists: {DATA_DIR_PATH}"
 INSTALL_DIR_PATH = __Path("__INSTALL_DIR__")  # /var/www/$app/
 assert INSTALL_DIR_PATH.is_dir(), f"Directory not exists: {INSTALL_DIR_PATH}"
 
-LOG_FILE_PATH = __Path("__LOG_FILE__")  # /var/log/$app/umap_ynh.log
-assert LOG_FILE_PATH.is_file(), f"File not exists: {LOG_FILE_PATH}"
+LOG_FILE_PATH = __Path("/var/log/__APP__/__APP__.log")  # /var/log/$app/umap_ynh.log
 
 PATH_URL = "__PATH__"
 PATH_URL = PATH_URL.strip("/")

--- a/manifest.toml
+++ b/manifest.toml
@@ -84,6 +84,7 @@ ram.runtime = "150M" # **estimate** minimum ram requirement. e.g. 50M, 400M, 1G,
     # This will create/remove the install dir as /var/www/$app/
     # and store the corresponding setting $install_dir and template variable __INSTALL_DIR__
     group = "www-data:r-x" # static files served by nginx
+    subdirs = ["data"]
 
     [resources.data_dir]
     # https://yunohost.org/en/packaging_apps_resources#data-dir

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,6 @@
 
 # Transfer the main SSO domain to the App:
 ynh_current_host=$(cat /etc/yunohost/current_host)
-__YNH_CURRENT_HOST__=${ynh_current_host} # FIXME: Useful? Sounds like not, and there is a confusion.
 
 umap_with_extra_deps="umap-project[yunohost,sync]"
 
@@ -17,28 +16,9 @@ umap_with_extra_deps="umap-project[yunohost,sync]"
 # e.g.: point pip cache to: /home/yunohost.app/$app/.cache/
 XDG_CACHE_HOME="$data_dir/.cache/"
 
-log_path=/var/log/$app
-log_file="${log_path}/${app}.log"
-
 #=================================================
 # HELPERS
 #=================================================
-
-#==================================================================================
-# Until we get a newer Python in YunoHost, see:
-# https://forum.yunohost.org/t/use-newer-python-than-3-9/22568
-#==================================================================================
-
-#==================================================================================
-#==================================================================================
-
-myynh_setup_log_file() {
-    mkdir -p "$(dirname "$log_file")"
-    touch "$log_file"
-
-    chown -c -R $app:$app "$log_path"
-    chmod -c u+rwx,o-rwx "$log_path"
-}
 
 myynh_fix_file_permissions() {
     # /var/www/$app/

--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ email=$(ynh_user_get_info --username=$admin --key=mail)
 #=================================================
 ynh_script_progression "Validating installation parameters..."
 
-mkdir -p "$data_dir/data" "$install_dir/static"
+mkdir -p "$install_dir/static"
 
 #=================================================
 # SETUP LOG FILE

--- a/scripts/install
+++ b/scripts/install
@@ -12,10 +12,6 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Storing installation settings..."
 
-# Logging:
-log_file="/var/log/$app/$app.log"
-ynh_app_setting_set --key=log_file --value="$log_file"
-
 # Redis:
 redis_db=$(ynh_redis_get_free_db)
 ynh_app_setting_set --key=redis_db --value="$redis_db"
@@ -37,10 +33,8 @@ mkdir -p "$data_dir/data" "$install_dir/static"
 #=================================================
 ynh_script_progression "Setup logging..."
 
-myynh_setup_log_file
-
 # Use logrotate to manage application logfile(s)
-ynh_config_add_logrotate "$log_file"
+ynh_config_add_logrotate
 
 #=================================================
 # PYTHON VIRTUALENV
@@ -124,7 +118,7 @@ myynh_fix_file_permissions
 #=================================================
 ynh_script_progression "Starting systemd service '$app'..."
 
-ynh_systemctl --service=$app --action="start" --log_path="$log_file"
+ynh_systemctl --service=$app --action="start"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -39,9 +39,8 @@ ynh_restore "/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_restore "/etc/systemd/system/$app.service"
 systemctl enable $app.service --quiet
 
-yunohost service add "$app" --description="Create maps with OpenStreetMap layers" --log="/var/log/$app/$app.log"
+yunohost service add "$app" --description="Create maps with OpenStreetMap layers"
 
-myynh_setup_log_file
 ynh_restore "/etc/logrotate.d/$app"
 
 #=================================================
@@ -56,7 +55,7 @@ myynh_fix_file_permissions
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service=$app --action="start" --log_path="$log_file"
+ynh_systemctl --service=$app --action="start"
 
 ynh_systemctl --service="nginx" --action="reload"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,7 +40,7 @@ ynh_app_setting_set_default --key=realtime --value=1
 ynh_config_add --template="settings.py" --destination="$install_dir/settings.py"
 ynh_config_add --template="setup_user.py" --destination="$install_dir/setup_user.py"
 ynh_config_add --template="env" --destination="$install_dir/.env"
-mkdir -p "$data_dir/data" "$install_dir/static"
+mkdir -p "$install_dir/static"
 
 #=================================================
 # copy icon files

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,7 +17,7 @@ email=$(ynh_user_get_info --username=$admin --key=mail)
 #=================================================
 ynh_script_progression "Stopping systemd service '$app'..."
 
-ynh_systemctl --service=$app --action="stop" --log_path="$log_file"
+ynh_systemctl --service=$app --action="stop"
 
 #=================================================
 # PYTHON VIRTUALENV
@@ -98,7 +98,7 @@ myynh_fix_file_permissions
 #=================================================
 ynh_script_progression "Starting systemd service '$app'..."
 
-ynh_systemctl --service=$app --action=restart --log_path=systemd
+ynh_systemctl --service="$app" --action="start"
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
- Remove the declaration of `__YNH_CURRENT_HOST__` which is in fact not used
- Remove `myynh_setup_log_file`, which is handled by the core (at least by `ynh_config_add_logrotate`, [source](https://github.com/YunoHost/yunohost/blob/184b29755161baf96c4360fceb8be4c2f1d60631/helpers/helpers.v2.1.d/logrotate#L46-L48))
- 